### PR TITLE
chore: refactor action inputs and update backend configuration

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -2,6 +2,22 @@ name: 'Terraform Destroy and Summary'
 description: 'Destroys Terraform-managed infrastructure and displays a summary in the GitHub Step Summary.'
 
 inputs:
+  release_tag:
+    description: 'Optional release tag to checkout'
+    required: false
+    type: string
+    default: ''
+
+  terraform-dir:
+    description: "Path to the Terraform configuration"
+    required: false
+    default: "tf"
+
+  tf-vars-file:
+    description: "Optional Terraform variable file"
+    required: false
+    default: "terraform.tfvars"
+
   s3-bucket:
     description: "S3 bucket for Terraform backend"
     required: true
@@ -10,19 +26,10 @@ inputs:
     description: "AWS region where the S3 bucket is located"
     required: true
 
-  dynamodb-table:
-    description: "DynamoDB table name for state locking"
-    required: true
-
-  terraform-dir:
-    description: 'Directory where Terraform code is located'
-    required: false
-    default: 'tf'
-
   ci-pipeline:
-    description: "Whether this is a CI pipeline"
+    description: "Set to true to use commit SHA in backend key"
     required: false
-    default: "true"
+    default: "false"
 
 runs:
   using: 'composite'
@@ -30,6 +37,8 @@ runs:
 
     - name: Checkout repo
       uses: actions/checkout@v4
+      with:
+        ref: ${{ inputs.release_tag || github.ref_name }} 
 
     - name: Setup Terraform
       uses: hashicorp/setup-terraform@v3
@@ -54,7 +63,7 @@ runs:
           -backend-config="key=${{ steps.key.outputs.s3_key }}" \
           -backend-config="region=${{ inputs.s3-region }}" \
           -backend-config="encrypt=true" \
-          -backend-config="dynamodb_table=${{ inputs.dynamodb-table }}"
+          -backend-config="use_lockfile=true"
 
     - name: Terraform Destroy
       id: destroy


### PR DESCRIPTION
This pull request updates the `action.yaml` file for the "Terraform Destroy and Summary" GitHub Action. The changes enhance flexibility in configuration, simplify backend setup, and refine input options.

### Enhancements to input options:

* Added new inputs: `release_tag`, `terraform-dir`, and `tf-vars-file` to provide optional customization for checking out specific tags, specifying Terraform configuration paths, and defining variable files.
* Modified the `ci-pipeline` input to clarify its purpose and set its default value to `false` instead of `true`.

### Backend configuration simplification:

* Removed the `dynamodb-table` input and replaced its usage with `use_lockfile=true` in the backend configuration, simplifying state locking.

### Workflow improvement:

* Updated the `Checkout repo` step to dynamically use the `release_tag` input or the current branch name (`github.ref_name`) for repository checkout.