### PR TITLE
feat: add multi cloud support for aws, gcp and azure

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -354,5 +354,4 @@ runs:
         END_TIME=$(date -u "+%Y-%m-%d %H:%M:%S UTC")
         echo "_**Completed at: ${END_TIME}**_" >> "$GITHUB_STEP_SUMMARY"
         echo "" >> "$GITHUB_STEP_SUMMARY"
-      shell: bash
 

--- a/action.yaml
+++ b/action.yaml
@@ -1,4 +1,4 @@
-name: 'Terraform Destroy and Summary'
+name: 'Terraform Destroy (Multi Cloud) and Summary'
 description: 'Destroys Terraform-managed infrastructure and displays a summary in the GitHub Step Summary.'
 
 inputs:


### PR DESCRIPTION
This pull request updates the GitHub Action configuration for destroying Terraform-managed infrastructure. The main change is a clarification in the action's name to indicate support for multi-cloud environments.

Action metadata update:

* Changed the action name in `action.yaml` to `'Terraform Destroy (Multi Cloud) and Summary'` to more clearly reflect multi-cloud support.

Minor formatting adjustment:

* Removed an unnecessary `shell: bash` line from the `runs:` section in `action.yaml`.